### PR TITLE
Add translating a specific message

### DIFF
--- a/translate/translate.py
+++ b/translate/translate.py
@@ -50,6 +50,27 @@ class Translate(commands.Cog):
         elif language.lower() in ("zh", "ch", "chinese"):
             language = "zh-cn"
 
+        # IF:
+        # - message is a string consisting solely of digits
+        # - message is a valid message id in the same channel
+        # - the message that the id points to has content
+        # THEN
+        # - replace message with the contents of that referenced message, and call translate on its contents
+        # OTHERWISE
+        # - continue like we used to
+        # eg
+        # JKohlman sent `this is a test message` with ID 1234
+        # JKohlman sent `[p]translate French 1234`
+        # Bot replies with the translation `this is a test message` -> `Ceci est un message test`
+        try:
+            if message.isdigit():
+                message_id = int(message)
+                ref_message = await ctx.fetch_message(message_id)
+                if ref_message.content:
+                    message = ref_message.content
+        except:
+            pass
+
         try:
             res = TRANSLATOR.translate(message, dest=language)
         except (ValueError, AttributeError):


### PR DESCRIPTION
Instead of having to copy/paste a message it would be very nice to specify a message to translate. I saw your plan of potential reaction-based translations and I think that would be a good idea but until that is complete there's not a great solution so I figured I'd make a solution in the meantime.

This code very simply adds a secondary syntax to `[p]translate` - if the `message` parameter passed is a valid message ID from the same channel then it changes the target of the translation to the contents of the referenced message.

Example:

1. I send the message `this is a test message` and that message has ID 1234.
2. I send the command `[p]translate French 1234`.
3. Bot replies with the translation of `this is a test message` -> `Ceci est un message test`

In the event of an error at any step this falls back on the default behavior.

I wasn't sure whether to do this like I did or whether a subcommand would be more appropriate. I'd love to hear feedback so I can adjust and prep for review/merging.