### PR TITLE
[Referrals] TypeError fix

### DIFF
--- a/referrals/referrals.py
+++ b/referrals/referrals.py
@@ -60,7 +60,7 @@ class Referrals(commands.Cog):
 
         log_channel = await self.config.guild(ctx.guild).log_channel()
         if log_channel:
-            log_channel = await ctx.guild.get_channel(log_channel)
+            log_channel = ctx.guild.get_channel(log_channel)
             if not (log_channel and log_channel.permissions_for(ctx.guild.me).send_messages):
                 log_channel = None
 


### PR DESCRIPTION
Fixes the following error:
```
Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/.local/share/Red-DiscordBot/data/SauriBot/cogs/CogManager/cogs/referrals/referrals.py", line 63, in _referredby
    log_channel = await ctx.guild.get_channel(log_channel)
TypeError: object TextChannel can't be used in 'await' expression

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 939, in invoke
    await ctx.command.invoke(ctx)
  File "/home/ubuntu/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 863, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/home/ubuntu/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: TypeError: object TextChannel can't be used in 'await' expression
```