### PR TITLE
[Counting] Fix `leaderboard` Error

### DIFF
--- a/counting/counting.py
+++ b/counting/counting.py
@@ -218,7 +218,8 @@ class Counting(commands.Cog):
         else:
             embed.description = "```py\nCounts | User\n"
             for member, counts in member_counts[:10]:
-                embed.description += f"{str(counts).rjust(6)}   {ctx.guild.get_member(member).display_name}\n"
+                mem = await self.bot.get_or_fetch_member(member)
+                embed.description += f"{str(counts).rjust(6)}   {mem.display_name}\n"
             embed.description += "```"
         return await ctx.send(embed=embed)
 


### PR DESCRIPTION
Replace `ctx.guild.get_member()` with `self.bot.get_or_fetch_member()` in `counting leaderboard` command since cache can not contain the member sometimes and will cause the bot to throw an unhandled error leading to the command not working.