### PR TITLE
Solved python warning preventing announcements from loading

### DIFF
--- a/announcements/__init__.py
+++ b/announcements/__init__.py
@@ -7,4 +7,4 @@ with open(Path(__file__).parent / "info.json") as fp:
 
 
 async def setup(bot):
-    bot.add_cog(Announcements(bot))
+    await bot.add_cog(Announcements(bot))


### PR DESCRIPTION
Fixed : RuntimeWarning: coroutine 'Red.add_cog' was never awaited
  bot.add_cog(Announcements(bot)) that prevented the cogs from loading